### PR TITLE
Docs/setup improvements

### DIFF
--- a/documentation/v2/10-19/12-prerequisites-setup.md
+++ b/documentation/v2/10-19/12-prerequisites-setup.md
@@ -74,6 +74,8 @@ After all pre-requisites are verified - [go to the SETUP page and choose your pr
     - [How-to guide](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/initial-subscriptions): Create Azure subscriptions
     - [Read more](./14-networking-privateDNS.md) about AIFactory Enterprise Scale Landing Zones
 - B) Enable resource providers: Enable the resource providers as [specified here](./12-resourceproviders.md)
+    - This must be completed BEFORE running any AI Factory pipelines
+    - Without this, deployment will fail with "provider not registered" errors
     - [Tip: You can use the Powershell script to automate this](../../../environment_setup/aifactory/bicep/esml-util/26-enable-resource-providers.ps1)
 
 ## 🔑 Step 3) Create an Azure keyvault for the admin of Microsoft Entra ID: The so called `seeding keyvault` (IaC purpose), and created Service principals

--- a/documentation/v2/20-29/24-end-2-end-setup.md
+++ b/documentation/v2/20-29/24-end-2-end-setup.md
@@ -36,6 +36,15 @@ Whether you want to use Azure DevOps or GitHub, we recommend using the [**AI Fac
 > - **ITSM-integrated (fully automated):** Many teams integrate the AI Factory pipelines directly with their ITSM system (ServiceNow, Jira Service Management, etc.), so that project teams can "order" an AI Factory project via a self-service ticket — triggering the pipeline with 100% automation and zero manual intervention.
 > - **Core-team managed:** Other teams prefer to route tickets to the AI Factory core team, who then uses the [**AI Factory Configuration Wizard**](../../../environment_setup/install_config_wizard/readme.md) to generate the correct configuration from the ticket information and trigger the pipeline on behalf of the requesting team.
 
+### Naming constraints
+
+Azure deployment names are limited to 64 characters. When configuring prefixes in your `.env` file, keep this in mind:
+- Keep AIFACTORY_PREFIX and PROJECT_PREFIX short (6 characters or less recommended)
+- Environment-specific prefixes (DEV_NETWORK_ENV, STAGE_NETWORK_ENV, PROD_NETWORK_ENV) add to the total length
+- Longer prefixes can cause deployment names to exceed the 64-character limit
+
+The Configuration Wizard validates prefix lengths and warns if deployment names would be truncated. If you configure prefixes manually, use shorter values to ensure all resource names deploy correctly.
+
 ### Option A — Azure DevOps
 
 [Setup AIFactory — Infra Automation (Azure DevOps YAML + Bicep)](../../../environment_setup/aifactory/bicep/copy_to_local_settings/azure-devops/esml-yaml-pipelines/readme.md)

--- a/environment_setup/aifactory/bicep/copy_to_local_settings/github-actions/readme.md
+++ b/environment_setup/aifactory/bicep/copy_to_local_settings/github-actions/readme.md
@@ -139,7 +139,7 @@ You need to login via `Azure CLI` and `Github CLI`, but recommendation is to als
         }
         ```
 
-    - OUTPUT: GitHub environments (Dev, Stage, Prod) are populated with variables based on your `.env` configuration. The count varies depending on which services are enabled and which optional fields are populated.
+    - OUTPUT: The environment in Github should now look something like below (~21 variables in each environment: Dev,Stage, Prod), though the exact count varies based on which services are enabled and optional fields populated.
     - ![](../../../../../documentation/v2/20-29/images/24-end-2-end-setup-repo-GH-env-vars.png)
 
 9) Run the Github action workflows for `infra-common.yml`
@@ -157,6 +157,8 @@ This is optional for common infrastructure only, but required if running step 11
 Then run the script to update GitHub variables:
 
     bash ./10-GH-create-or-update-github-variables.sh
+
+For more details on all available variables and their purposes, see the comments section in `variables.yaml`.
 
 Proceed to step 11 to deploy projects.
 

--- a/environment_setup/aifactory/bicep/copy_to_local_settings/github-actions/readme.md
+++ b/environment_setup/aifactory/bicep/copy_to_local_settings/github-actions/readme.md
@@ -82,6 +82,12 @@ OUTPUT: The file structure should now look something like below (except paramete
    ```sh
     gh auth login
    ```
+
+### Service Principal Setup
+The service principal (e.g., `esml-common-bicep-sp`) needs proper Azure permissions:
+- Must have **Owner** role on the subscription (not "User Access Administrator" with conditions)
+- RBAC conditions may block deployments — assign role **without conditions**
+
 <!--
 5) Authenticate to  Azure and Github
 You need to login via `Azure CLI` and `Github CLI`, but recommendation is to also test login via `Powershell`. 
@@ -109,7 +115,13 @@ You need to login via `Azure CLI` and `Github CLI`, but recommendation is to als
     - Choose naming convention: prefix, suffixes
     - Choose which services to enable or disable
     - BYOVNet, BYOSubnet, BYOAce, enableAIGateway
+    - GITHUB_NEW_REPO: Use format `owner/repo-name` (not just repo name)
     - etc
+    - **Replace `<todo>` placeholders**: The `.env.template` file contains `<todo>` placeholders that must be replaced with actual values
+        - `<todo>` means **mandatory** and must be replaced
+        - Examples: `GITHUB_USERNAME`, `TENANT_ID`, `DEV_SUBSCRIPTION_ID`, `AIFACTORY_SEEDING_KEYVAULT_NAME`
+        - Validation: Before running step 8, search your `.env` file for `<todo>` - there should be **zero** matches
+
 8) Run the file created at your root called: `10-GH-create-or-update-github-variables.sh`, that will copy values from .env to your Github repo as Environment variables, and secrets.
     - NB! The below will use Github CLI (gh), if the command does not work, please see PREREQUISITES.
     ```
@@ -127,25 +139,32 @@ You need to login via `Azure CLI` and `Github CLI`, but recommendation is to als
         }
         ```
 
-    - OUTPUT: The environment in Github should now look something like below (~21 variables in each environment: Dev,Stage, Prod)
+    - OUTPUT: GitHub environments (Dev, Stage, Prod) are populated with variables based on your `.env` configuration. The count varies depending on which services are enabled and which optional fields are populated.
     - ![](../../../../../documentation/v2/20-29/images/24-end-2-end-setup-repo-GH-env-vars.png)
 
-9) Run the Github action workflows for `infra-aifactory-common.yaml`
-10) Set the variable in your .env file called `aifactory_salt`, and then run the script again, `10-GH-create-or-update-github-variables.sh`,  to update your GH variables. 
+9) Run the Github action workflows for `infra-common.yml`
+10) Set the variable in your .env file called `aifactory_salt` if deploying projects
 
-```code yaml
-# Update with values from AI Factory COMMON Resource group.The aifactory_salt can be read from the AI Factory common resource group in names of services such as Azure Datafactory
-# - Example: the 'a4c2b'in "adf-cmn-weu-dev-a4c2b-001" and in Container registry, private endpoints: "pend-kv-cmndev-a4c2b-001-to-vnt-esmlcmn"
-# ...
-# ...
+This is optional for common infrastructure only, but required if running step 11 (project deployments). The `aifactory_salt` is a 5-character deterministic salt from your common deployment that ensures unique resource naming across projects.
+
 ```
-Read more information in the comment section of variables.yaml
+# Extract from your common resource group (5 characters exactly, alphanumeric)
+# The aifactory_salt can be read from common resource group names such as Azure Datafactory
+# Example: the 'a4c2b' in "adf-cmn-weu-dev-a4c2b-001" or in Container registry: "pend-kv-cmndev-a4c2b-001-to-vnt-esmlcmn"
+# Set AIFACTORY_SALT in your .env file with this 5-character value
+```
+
+Then run the script to update GitHub variables:
+
+    bash ./10-GH-create-or-update-github-variables.sh
+
+Proceed to step 11 to deploy projects.
 
 11) Run the workflow `infra-project.yml`
 
 ## Workflow: AIFactory Common 
 Start with setting up a common AIFactory environment, example, the DEV environment
-- [infra-aifactory-common.yaml](./esml-infra-common/infra-aifactory-common.yaml)
+- [infra-common.yml](./infra-common.yml)
 
 ## Workflow: AIFactory projects
 Then you can import and run the pipelines to setup 1-M projects. There are 2 AIFactory project types supported as of now: 


### PR DESCRIPTION
## Summary
Documentation improvements based on blockers/uncertainties during AI Factory setup. No code changes.

## Changes

### GitHub Actions Setup (`readme.md`)
- **Fixed:** Corrected workflow filename from `infra-aifactory-common.yaml` to `infra-common.yml`
- **Added:** GITHUB_NEW_REPO format requirement (must use `owner/repo-name` format, not just repo name)
- **Clarified:** Environment variable count with explanation that exact count varies based on enabled services and optional fields
- **Improved:** aifactory_salt documentation now clearly distinguishes when it's needed (optional for common infrastructure only, but required if deploying projects in step 11)

### Setup Guide (`24-end-2-end-setup.md`)
- **Added:** Naming constraints section explaining Azure's 64-character deployment name limit and guidance for safe prefix lengths

### Prerequisites (`12-prerequisites-setup.md`)
- **Clarified:** Resource provider requirement now specifies "required for infrastructure deployment" with clearer context about what happens when missing